### PR TITLE
Call freeaddrinfo only after a successful call to getaddrinfo

### DIFF
--- a/src/c/profile/transport/ip/tcp/tcp_transport_posix.c
+++ b/src/c/profile/transport/ip/tcp/tcp_transport_posix.c
@@ -67,8 +67,8 @@ bool uxr_init_tcp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/tcp/tcp_transport_posix_nopoll.c
+++ b/src/c/profile/transport/ip/tcp/tcp_transport_posix_nopoll.c
@@ -55,8 +55,8 @@ bool uxr_init_tcp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/tcp/tcp_transport_windows.c
+++ b/src/c/profile/transport/ip/tcp/tcp_transport_windows.c
@@ -59,8 +59,8 @@ bool uxr_init_tcp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/udp/udp_transport_posix.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_posix.c
@@ -66,8 +66,8 @@ bool uxr_init_udp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/udp/udp_transport_posix_nopoll.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_posix_nopoll.c
@@ -57,8 +57,8 @@ bool uxr_init_udp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }

--- a/src/c/profile/transport/ip/udp/udp_transport_windows.c
+++ b/src/c/profile/transport/ip/udp/udp_transport_windows.c
@@ -58,8 +58,8 @@ bool uxr_init_udp_platform(
                     break;
                 }
             }
+            freeaddrinfo(result);
         }
-        freeaddrinfo(result);
     }
     return rv;
 }


### PR DESCRIPTION
If getaddrinfo fails, result is not allocated